### PR TITLE
Added require json to readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ All requests to the Congress API require a Sunlight API key. An API key is
 
 ###### Setup
 ```ruby
+require 'json'
 require 'congress'
 Congress.key = YOUR_SUNLIGHT_API_KEY
 ```


### PR DESCRIPTION
To assist newer ruby developers who might hit an error (shown below), I've added `require 'json'` to the code example in the readme file. 

Under Ruby 2.0.0p247 when attempting to use the example code, the following error is presented: 

```
[1] pry(main)> Congress.legislators
Faraday::Error::ParsingError: uninitialized constant JSON::Parser
from /Users/tibbon/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/json/common.rb:155:in `parse'
```

All tests still pass, and no changes to other code were made. Verified issue on several computers. 
