### PR TITLE
Fix bug that breaks zip code lookup for any zip code that starts with a leading zero

### DIFF
--- a/lib/congress/client.rb
+++ b/lib/congress/client.rb
@@ -123,7 +123,7 @@ module Congress
       options = args.last.is_a?(::Hash) ? args.pop : {}
       case [args.size, args.first.class]
       when [1, Fixnum]
-        options.merge(:zip => args.pop)
+        options.merge(:zip => to_zip_code(args.pop))
       when [1, String]
         placemark = Geocoder.search(args.pop).first
         options.merge(:longitude => placemark.longitude, :latitude => placemark.latitude)
@@ -132,6 +132,13 @@ module Congress
       else
         fail ArgumentError, 'Must pass a latitude/longitude, zip or address'
       end
+    end
+
+    # Proper zip code from a number, adding leading zeroes if required
+    # @param number [Integer] zip code as an integer
+    # @return [String]
+    def to_zip_code(number)
+      sprintf('%05d', number)
     end
   end
 end

--- a/spec/congress/client_spec.rb
+++ b/spec/congress/client_spec.rb
@@ -23,7 +23,7 @@ describe Congress::Client do
   describe '#legislators_locate' do
     context 'with a zip code passed' do
       before do
-        stub_get('/legislators/locate?zip=94107').
+        stub_get('/legislators/locate').with(:query => hash_including('zip')).
           to_return(:status => 200, :body => fixture('legislators_locate.json'))
       end
       it 'fetches representatives and senators for a zip code' do
@@ -31,6 +31,12 @@ describe Congress::Client do
         expect(a_get('/legislators/locate?zip=94107').with(:headers => {'X-APIKEY' => 'abc123'})).to have_been_made
         expect(legislators_locate['count']).to eq(3)
         expect(legislators_locate['results'].first.bioguide_id).to eq('P000197')
+      end
+      context 'zip code with leading zeroes' do
+        it 'pads with leading zeroes' do
+          @client.legislators_locate(6511)
+          expect(a_get('/legislators/locate?zip=06511').with(:headers => {'X-APIKEY' => 'abc123'})).to have_been_made
+        end
       end
     end
     context 'with a latitude and longitude passed' do


### PR DESCRIPTION
All tests and coverage tools pass cleanly.

If you are OK with it, I'd like to send along another pull request that makes the extract_location method smart enough to recognize a 5-digit string as a zip code.
