### PR TITLE
Update hashie dependency. Use Mashie instead of Rashie

### DIFF
--- a/congress.gemspec
+++ b/congress.gemspec
@@ -4,8 +4,7 @@ require File.expand_path('../lib/congress/version', __FILE__)
 Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 0.9.0'
   spec.add_dependency 'faraday_middleware', '~> 0.9.1'
-  spec.add_dependency 'hashie', '~> 2.0'
-  spec.add_dependency 'rash', '~> 0.4'
+  spec.add_dependency 'hashie', '~> 3.0'
   spec.add_dependency 'geocoder', '~> 1.2'
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.author        = 'Erik Michaels-Ober'

--- a/lib/congress/connection.rb
+++ b/lib/congress/connection.rb
@@ -20,7 +20,7 @@ module Congress
     def middlewares
       [Faraday::Request::UrlEncoded,
        Faraday::Response::RaiseError,
-       Faraday::Response::Rashify,
+       Faraday::Response::Mashify,
        Faraday::Response::ParseJson]
     end
   end


### PR DESCRIPTION
A project I'm working on has another dependency that requires hashie 3.x so I started down the road of creating a pull to update rash(currently locked at 2.x) to use hashie 3.x. https://github.com/wzcolon/rash

Compounding the problem, the fix for rash to be able to use hashie 3.x required changing the namespace because hashie itself now uses the Hashie::Rash namespace. 

To keep this project working, this would require a code change in faraday_middleware to make use of the new Hashie::Hash::Rash namespace.

It looks like all the test cases pass using Hashie::Mash so I'm suggesting to update hashie and just use Hashie::Mash moving forward. 